### PR TITLE
Use a proper cache for ancestors and descendants

### DIFF
--- a/src/main/java/ubc/pavlab/rdp/repositories/GeneOntologyTermInfoRepository.java
+++ b/src/main/java/ubc/pavlab/rdp/repositories/GeneOntologyTermInfoRepository.java
@@ -4,11 +4,19 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import ubc.pavlab.rdp.model.Gene;
 import ubc.pavlab.rdp.model.GeneOntologyTermInfo;
 
 import java.util.*;
 
+/**
+ * Repository of gene ontology terms and gene-to-term relationships.
+ * <p>
+ * Note: this repository does not support {@link org.springframework.transaction.annotation.Transactional} operations,
+ * nor should be considered thread-safe. We highly recommend initializing it once and updating it periodically from a
+ * single thread.
+ *
+ * @author poirigui
+ */
 @Repository
 public class GeneOntologyTermInfoRepository implements CrudRepository<GeneOntologyTermInfo, String> {
 
@@ -70,9 +78,8 @@ public class GeneOntologyTermInfoRepository implements CrudRepository<GeneOntolo
         return results;
     }
 
-    @SuppressWarnings("SpringDataMethodInconsistencyInspection")
-    public Collection<GeneOntologyTermInfo> findAllByGene( Gene gene ) {
-        return geneIdsToTerms.getOrDefault( gene.getGeneId(), Collections.emptyList() );
+    public Collection<GeneOntologyTermInfo> findByDirectGeneIdsContaining( Integer geneId ) {
+        return geneIdsToTerms.getOrDefault( geneId, Collections.emptyList() );
     }
 
     @Override

--- a/src/main/java/ubc/pavlab/rdp/repositories/GeneOntologyTermInfoRepository.java
+++ b/src/main/java/ubc/pavlab/rdp/repositories/GeneOntologyTermInfoRepository.java
@@ -12,9 +12,9 @@ import java.util.*;
 @Repository
 public class GeneOntologyTermInfoRepository implements CrudRepository<GeneOntologyTermInfo, String> {
 
-    private Map<String, GeneOntologyTermInfo> terms = new HashMap<>();
+    private final Map<String, GeneOntologyTermInfo> terms = new HashMap<>();
 
-    private MultiValueMap<Integer, GeneOntologyTermInfo> geneIdsToTerms = new LinkedMultiValueMap<>();
+    private final MultiValueMap<Integer, GeneOntologyTermInfo> geneIdsToTerms = new LinkedMultiValueMap<>();
 
     @Override
     public <S extends GeneOntologyTermInfo> S save( S term ) {
@@ -23,11 +23,11 @@ public class GeneOntologyTermInfoRepository implements CrudRepository<GeneOntolo
 
     @Override
     public <S extends GeneOntologyTermInfo> Iterable<S> save( Iterable<S> iterable ) {
-        List<GeneOntologyTermInfo> savedTerms = new ArrayList<>();
-        for ( GeneOntologyTermInfo term : iterable ) {
+        List<S> savedTerms = new ArrayList<>();
+        for ( S term : iterable ) {
             savedTerms.add( save( term ) );
         }
-        return (Iterable<S>) savedTerms;
+        return savedTerms;
     }
 
     public <S extends GeneOntologyTermInfo> S saveAlias( String alias, S term ) {
@@ -38,12 +38,12 @@ public class GeneOntologyTermInfoRepository implements CrudRepository<GeneOntolo
         return term;
     }
 
-    public <S extends GeneOntologyTermInfo> Iterable<S> saveAlias( Map<String, GeneOntologyTermInfo> terms ) {
-        List<GeneOntologyTermInfo> savedTerms = new ArrayList<>( terms.size() );
-        for ( Map.Entry<String, GeneOntologyTermInfo> entry : terms.entrySet() ) {
+    public <S extends GeneOntologyTermInfo> Iterable<S> saveAlias( Map<String, S> terms ) {
+        List<S> savedTerms = new ArrayList<>( terms.size() );
+        for ( Map.Entry<String, S> entry : terms.entrySet() ) {
             savedTerms.add( saveAlias( entry.getKey(), entry.getValue() ) );
         }
-        return (Iterable<S>) savedTerms;
+        return savedTerms;
     }
 
     @Override
@@ -70,6 +70,7 @@ public class GeneOntologyTermInfoRepository implements CrudRepository<GeneOntolo
         return results;
     }
 
+    @SuppressWarnings("SpringDataMethodInconsistencyInspection")
     public Collection<GeneOntologyTermInfo> findAllByGene( Gene gene ) {
         return geneIdsToTerms.getOrDefault( gene.getGeneId(), Collections.emptyList() );
     }

--- a/src/main/java/ubc/pavlab/rdp/services/GOServiceImpl.java
+++ b/src/main/java/ubc/pavlab/rdp/services/GOServiceImpl.java
@@ -350,7 +350,7 @@ public class GOServiceImpl implements GOService {
 
     @Override
     public Collection<GeneOntologyTermInfo> getTermsForGene( Gene gene ) {
-        return goRepository.findAllByGene( gene );
+        return goRepository.findByDirectGeneIdsContaining( gene.getGeneId() );
     }
 
     @Override
@@ -358,7 +358,7 @@ public class GOServiceImpl implements GOService {
 
         Collection<GeneOntologyTermInfo> allGOTermSet = new HashSet<>();
 
-        for ( GeneOntologyTermInfo term : goRepository.findAllByGene( gene ) ) {
+        for ( GeneOntologyTermInfo term : goRepository.findByDirectGeneIdsContaining( gene.getGeneId() ) ) {
             allGOTermSet.add( term );
 
             if ( propagateUpwards ) {

--- a/src/main/java/ubc/pavlab/rdp/services/GOServiceImpl.java
+++ b/src/main/java/ubc/pavlab/rdp/services/GOServiceImpl.java
@@ -22,11 +22,10 @@ import ubc.pavlab.rdp.util.SearchResult;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import java.util.zip.GZIPInputStream;
 
 import static java.util.function.Function.identity;
@@ -40,6 +39,10 @@ import static java.util.stream.Collectors.groupingBy;
 @CommonsLog
 public class GOServiceImpl implements GOService {
 
+    private static String
+            ANCESTORS_CACHE_NAME = "ubc.pavlab.rdp.services.GOService.ancestors",
+            DESCENDANTS_CACHE_NAME = "ubc.pavlab.rdp.services.GOService.descendants";
+
     @Autowired
     private GeneOntologyTermInfoRepository goRepository;
 
@@ -51,6 +54,9 @@ public class GOServiceImpl implements GOService {
 
     @Autowired
     private Gene2GoParser gene2GoParser;
+
+    @Autowired
+    private CacheManager cacheManager;
 
     private static Relationship convertRelationship( OBOParser.Relationship parsedRelationship ) {
         return new Relationship( convertTermIgnoringRelationship( parsedRelationship.getNode() ),
@@ -149,10 +155,6 @@ public class GOServiceImpl implements GOService {
             log.warn( MessageFormat.format( "{0} more terms were missing from {1}, their direct genes will also be ignored.", missingFromTermFile.size() - 5, cacheSettings.getTermFile() ) );
         }
 
-        log.info( "Clearing ancestor and descendants cache as it is no longer fresh." );
-        ancestorsCache.clear();
-        descendantsCache.clear();
-
         log.info( MessageFormat.format( "Done updating GO terms, total of {0} items.", count() ) );
     }
 
@@ -225,27 +227,47 @@ public class GOServiceImpl implements GOService {
 
     @Override
     public GeneOntologyTermInfo save( GeneOntologyTermInfo term ) {
-        return goRepository.save( term );
+        try {
+            return goRepository.save( term );
+        } finally {
+            evict( term );
+        }
     }
 
     @Override
     public Iterable<GeneOntologyTermInfo> save( Iterable<GeneOntologyTermInfo> terms ) {
-        return goRepository.save( terms );
+        try {
+            return goRepository.save( terms );
+        } finally {
+            evict( terms );
+        }
     }
 
     @Override
     public GeneOntologyTermInfo saveAlias( String goId, GeneOntologyTermInfo term ) {
-        return goRepository.saveAlias( goId, term );
+        try {
+            return goRepository.saveAlias( goId, term );
+        } finally {
+            evict( term );
+        }
     }
 
     @Override
     public Iterable<GeneOntologyTermInfo> saveAlias( Map<String, GeneOntologyTermInfo> terms ) {
-        return goRepository.saveAlias( terms );
+        try {
+            return goRepository.saveAlias( terms );
+        } finally {
+            evict( terms.values() );
+        }
     }
 
     @Override
     public void deleteAll() {
-        goRepository.deleteAll();
+        try {
+            goRepository.deleteAll();
+        } finally {
+            evictAll();
+        }
     }
 
     @Override
@@ -258,12 +280,14 @@ public class GOServiceImpl implements GOService {
         return getDescendantsInternal( entry );
     }
 
-    private ConcurrentMap<GeneOntologyTermInfo, Set<GeneOntologyTermInfo>> descendantsCache = new ConcurrentHashMap<>();
-
     private Set<GeneOntologyTermInfo> getDescendantsInternal( GeneOntologyTermInfo entry ) {
-        if ( descendantsCache.containsKey( entry ) )
-            return descendantsCache.get( entry );
-        Set<GeneOntologyTermInfo> results = new HashSet<>();
+        Cache descendantsCache = cacheManager.getCache( DESCENDANTS_CACHE_NAME );
+        //noinspection unchecked
+        Set<GeneOntologyTermInfo> results = descendantsCache.get( entry, Set.class );
+        if ( results != null ) {
+            return results;
+        }
+        results = new HashSet<>();
         for ( GeneOntologyTermInfo child : getChildren( entry ) ) {
             results.add( child );
             results.addAll( getDescendantsInternal( child ) );
@@ -357,17 +381,59 @@ public class GOServiceImpl implements GOService {
         return getAncestorsInternal( term );
     }
 
-    private ConcurrentMap<GeneOntologyTermInfo, Set<GeneOntologyTermInfo>> ancestorsCache = new ConcurrentHashMap<>();
-
     private Collection<GeneOntologyTermInfo> getAncestorsInternal( GeneOntologyTermInfo term ) {
-        if ( ancestorsCache.containsKey( term ) )
-            return ancestorsCache.get( term );
-        Set<GeneOntologyTermInfo> results = new HashSet<>();
+        Cache ancestorsCache = cacheManager.getCache( ANCESTORS_CACHE_NAME );
+        //noinspection unchecked
+        Set<GeneOntologyTermInfo> results = ancestorsCache.get( term, Set.class );
+        if ( results != null )
+            return results;
+        results = new HashSet<>();
         for ( GeneOntologyTermInfo parent : getParents( term ) ) {
             results.add( parent );
             results.addAll( getAncestorsInternal( parent ) );
         }
         ancestorsCache.put( term, results );
         return results;
+    }
+
+    private void evict( GeneOntologyTermInfo term ) {
+        evict( Collections.singleton( term ) );
+    }
+
+    private void evict( Iterable<GeneOntologyTermInfo> terms ) {
+        Cache ancestorsCache = cacheManager.getCache( ANCESTORS_CACHE_NAME );
+        Cache descendantsCache = cacheManager.getCache( DESCENDANTS_CACHE_NAME );
+
+        // first, let's retrieve what we already have in the cache
+        Collection<GeneOntologyTermInfo> ancestors = StreamSupport.stream( terms.spliterator(), false )
+                .map( this::getAncestors )
+                .flatMap( Collection::stream )
+                .collect( Collectors.toSet() );
+        Collection<GeneOntologyTermInfo> descendants = StreamSupport.stream( terms.spliterator(), false )
+                .map( this::getDescendants )
+                .flatMap( Collection::stream )
+                .collect( Collectors.toSet() );
+
+        // evict the terms from both caches
+        for ( GeneOntologyTermInfo term : terms ) {
+            ancestorsCache.evict( term );
+            descendantsCache.evict( term );
+        }
+
+        // all the ancestors mention one of the updated terms in their descendants, so we evict those
+        for ( GeneOntologyTermInfo ancestor : ancestors ) {
+            descendantsCache.evict( ancestor );
+        }
+
+        // conversely, all the descendants mention one of the updated term in their ancestors
+        for ( GeneOntologyTermInfo descendant : descendants ) {
+            ancestorsCache.evict( descendant );
+        }
+    }
+
+    private void evictAll() {
+        log.info( "Clearing ancestor and descendants cache as it is no longer fresh." );
+        cacheManager.getCache( ANCESTORS_CACHE_NAME ).clear();
+        cacheManager.getCache( DESCENDANTS_CACHE_NAME ).clear();
     }
 }

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -62,4 +62,12 @@
     <cache name="ubc.pavlab.rdp.services.UserService.remoteSearchUser"
            maxElementsInMemory="1"
            eternal="true"/>
+
+    <cache name="ubc.pavlab.rdp.services.GOService.ancestors"
+           maxElementsInMemory="10000"
+           eternal="true"/>
+
+    <cache name="ubc.pavlab.rdp.services.GOService.descendants"
+           maxElementsInMemory="10000"
+           eternal="true"/>
 </ehcache>

--- a/src/test/java/ubc/pavlab/rdp/services/GOServiceImplTest.java
+++ b/src/test/java/ubc/pavlab/rdp/services/GOServiceImplTest.java
@@ -8,6 +8,8 @@ import org.mockito.internal.util.collections.Sets;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -69,6 +71,11 @@ public class GOServiceImplTest {
         @Bean
         public GeneOntologyTermInfoRepository goRepository() {
             return new GeneOntologyTermInfoRepository();
+        }
+
+        @Bean
+        public CacheManager cacheManager() {
+            return new EhCacheCacheManager();
         }
     }
 


### PR DESCRIPTION
Evict terms when they are updated or removed from the two caches.