### PR TITLE
Add PurlResolver to resolve PURLs and register it on the application context (fix #187)

### DIFF
--- a/src/main/java/ubc/pavlab/rdp/services/GOServiceImpl.java
+++ b/src/main/java/ubc/pavlab/rdp/services/GOServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 import ubc.pavlab.rdp.model.Gene;
 import ubc.pavlab.rdp.model.GeneOntologyTermInfo;
@@ -51,6 +52,9 @@ public class GOServiceImpl implements GOService {
 
     @Autowired
     private Gene2GoParser gene2GoParser;
+
+    @Autowired
+    private ResourceLoader resourceLoader;
 
     private static Relationship convertRelationship( OBOParser.Relationship parsedRelationship ) {
         return new Relationship( convertTermIgnoringRelationship( parsedRelationship.getNode() ),
@@ -104,7 +108,7 @@ public class GOServiceImpl implements GOService {
 
         Map<String, GeneOntologyTermInfo> terms;
         try {
-            terms = convertTerms( oboParser.parseStream( cacheSettings.getTermFile().getInputStream() ) );
+            terms = convertTerms( oboParser.parseStream( resourceLoader.getResource( cacheSettings.getTermFile() ).getInputStream() ) );
         } catch ( IOException | ParseException e ) {
             log.error( "Failed to parse GO terms.", e );
             return;

--- a/src/main/java/ubc/pavlab/rdp/services/OrganInfoServiceImpl.java
+++ b/src/main/java/ubc/pavlab/rdp/services/OrganInfoServiceImpl.java
@@ -3,6 +3,7 @@ package ubc.pavlab.rdp.services;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ubc.pavlab.rdp.model.OrganInfo;
@@ -28,6 +29,9 @@ public class OrganInfoServiceImpl implements OrganInfoService {
     @Autowired
     private ApplicationSettings applicationSettings;
 
+    @Autowired
+    private ResourceLoader resourceLoader;
+
     @Override
     public Collection<OrganInfo> findAll() {
         return organInfoRepository.findAll();
@@ -47,7 +51,10 @@ public class OrganInfoServiceImpl implements OrganInfoService {
     @Transactional
     public void updateOrganInfos() {
         try {
-            Resource organFile = applicationSettings.getCache().getOrganFile();
+            Resource organFile = null;
+            if ( applicationSettings.getCache().getOrganFile() != null ) {
+                organFile = resourceLoader.getResource( applicationSettings.getCache().getOrganFile() );
+            }
             if ( organFile == null ) {
                 log.warn( "No organ system ontology file found, skipping update." );
                 return;

--- a/src/main/java/ubc/pavlab/rdp/settings/ApplicationSettings.java
+++ b/src/main/java/ubc/pavlab/rdp/settings/ApplicationSettings.java
@@ -39,9 +39,11 @@ public class ApplicationSettings {
         /**
          * Location of GO terms.
          */
-        private Resource termFile;
+        private String termFile;
         /**
          * Location of gene2go annotations.
+         * <p>
+         * FIXME: use a {@link Resource}, but resolving is not supported at the config-level (see <a href="https://github.com/PavlidisLab/rdp/pull/192">#192</a>)
          */
         private Resource annotationFile;
         /**
@@ -50,8 +52,10 @@ public class ApplicationSettings {
         private Resource orthologFile;
         /**
          * Location of organ system terms.
+         * <p>
+         * FIXME: use a {@link Resource}, but resolving is not supported at the config-level (see <a href="https://github.com/PavlidisLab/rdp/pull/192">#192</a>)
          */
-        private Resource organFile;
+        private String organFile;
 
     }
 

--- a/src/main/java/ubc/pavlab/rdp/util/PurlResolver.java
+++ b/src/main/java/ubc/pavlab/rdp/util/PurlResolver.java
@@ -1,0 +1,74 @@
+package ubc.pavlab.rdp.util;
+
+import lombok.extern.apachecommons.CommonsLog;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.*;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Resolve resources from <a href="http://purl.obolibrary.org">purl.obolibrary.org</a>.
+ *
+ * @author poirigui
+ */
+@Component
+@CommonsLog
+public class PurlResolver implements ProtocolResolver, ResourceLoaderAware, ApplicationContextAware {
+
+    /**
+     * Check if the provided URL refers to a PURL resource.
+     */
+    private static boolean isPurl( URL url ) {
+        return url.getProtocol().equals( "http" ) && url.getHost().equals( "purl.obolibrary.org" );
+    }
+
+    @Override
+    public Resource resolve( String location, ResourceLoader resourceLoader ) {
+        HttpURLConnection con = null;
+        try {
+            URL url = new URL( location );
+            if ( isPurl( url ) ) {
+                con = (HttpURLConnection) url.openConnection();
+                con.setInstanceFollowRedirects( false );
+                if ( con.getHeaderField( "Location" ) != null ) {
+                    return new UrlResource( con.getHeaderField( "Location" ) );
+                }
+            }
+        } catch ( MalformedURLException e ) {
+            return null;
+        } catch ( IOException e ) {
+            log.error( "Failed to resolve %s.", e );
+            if ( con != null ) {
+                con.disconnect();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void setResourceLoader( ResourceLoader resourceLoader ) {
+        if ( resourceLoader instanceof DefaultResourceLoader ) {
+            ( (DefaultResourceLoader) resourceLoader ).addProtocolResolver( new PurlResolver() );
+            log.info( String.format( "Registered %s to the resource loader %s.", PurlResolver.class, resourceLoader ) );
+        } else {
+            log.warn( String.format( "Could not register %s to the resource loader %s. PURL URLs might not be resolved correctly.", PurlResolver.class, resourceLoader ) );
+        }
+    }
+
+    @Override
+    public void setApplicationContext( ApplicationContext applicationContext ) throws BeansException {
+        // FIXME: This is necessary because protocol resolvers are not honored if a resource loader is set on the application context (see https://github.com/spring-projects/spring-framework/issues/28703)
+        if ( applicationContext instanceof GenericApplicationContext ) {
+            GenericApplicationContext genericApplicationContext = (GenericApplicationContext) applicationContext;
+            genericApplicationContext.setResourceLoader( null );
+        }
+    }
+}

--- a/src/test/java/ubc/pavlab/rdp/services/GOServiceImplTest.java
+++ b/src/test/java/ubc/pavlab/rdp/services/GOServiceImplTest.java
@@ -45,7 +45,7 @@ public class GOServiceImplTest {
             ApplicationSettings a = new ApplicationSettings();
             ApplicationSettings.CacheSettings cacheSettings = new ApplicationSettings.CacheSettings();
             cacheSettings.setEnabled( false );
-            cacheSettings.setTermFile( new ClassPathResource( "cache/go.obo" ) );
+            cacheSettings.setTermFile( "classpath:cache/go.obo" );
             cacheSettings.setAnnotationFile( new ClassPathResource( "cache/gene2go.gz" ) );
             a.setCache( cacheSettings );
             return a;

--- a/src/test/java/ubc/pavlab/rdp/util/PurlResolverTest.java
+++ b/src/test/java/ubc/pavlab/rdp/util/PurlResolverTest.java
@@ -1,0 +1,55 @@
+package ubc.pavlab.rdp.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeNoException;
+
+@Import(PurlResolver.class)
+@RunWith(SpringRunner.class)
+public class PurlResolverTest {
+
+    @Autowired
+    private ResourceLoader resourceLoader;
+
+    @Test
+    public void test() {
+        assertThat( resourceLoader ).isInstanceOf( DefaultResourceLoader.class );
+        assertThat( ( (DefaultResourceLoader) resourceLoader ).getProtocolResolvers() )
+                .hasSize( 1 )
+                .first()
+                .isInstanceOf( PurlResolver.class );
+    }
+
+    @Test
+    public void getResource() {
+        Resource resource = resourceLoader.getResource( "http://purl.obolibrary.org/obo/uberon.obo" );
+        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( resource.getInputStream() ) ) ) {
+            assertThat( reader.readLine() ).startsWith( "format-version:" );
+        } catch ( IOException e ) {
+            assumeNoException( "Network is likely unavailable for reaching purl.obolibrary.org.", e );
+        }
+    }
+
+    @Test
+    public void getResource_withRegularResourceLoader_thenFailToResolveUberon() {
+        Resource resource = new DefaultResourceLoader().getResource( "http://purl.obolibrary.org/obo/uberon.obo" );
+        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( resource.getInputStream() ) ) ) {
+            assertThat( reader.readLine() ).doesNotStartWith( "format-version:" );
+        } catch ( IOException e ) {
+            assumeNoException( "Network is likely unavailable for reaching purl.obolibrary.org.", e );
+        }
+    }
+
+}


### PR DESCRIPTION
Unfortunately, a workaround is needed so that GenericApplicationContext honours the custom resolvers.

Related: https://github.com/spring-projects/spring-framework/issues/28703