### PR TITLE
Add a MAC signature on the secure tokens

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,6 +53,9 @@ spring.mail.password=<mail password>
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+# generate a secret key and assign it here
+rdp.settings.signature-key=<secret key>
+
 # Adjust this to your own network name
 rdp.site.fullname=Rare Disease Model & Mechanism Network
 rdp.site.shortname=RDMM

--- a/src/main/java/ubc/pavlab/rdp/SecureTokenConfig.java
+++ b/src/main/java/ubc/pavlab/rdp/SecureTokenConfig.java
@@ -2,7 +2,11 @@ package ubc.pavlab.rdp;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import ubc.pavlab.rdp.settings.ApplicationSettings;
+import ubc.pavlab.rdp.util.MacFactory;
 
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
@@ -17,5 +21,13 @@ public class SecureTokenConfig {
     @Bean
     public SecureRandom secureRandom() throws NoSuchAlgorithmException {
         return SecureRandom.getInstance( "SHA1PRNG" );
+    }
+
+    @Bean
+    public MacFactory macFactory( ApplicationSettings applicationSettings ) {
+        MacFactory factory = new MacFactory();
+        factory.setAlgorithm( applicationSettings.getSignatureAlgorithm() );
+        factory.setKey( new SecretKeySpec( applicationSettings.getSignatureKey().getBytes( StandardCharsets.UTF_8 ), "HmacSHA256" ) );
+        return factory;
     }
 }

--- a/src/main/java/ubc/pavlab/rdp/exception/InvalidTokenSignatureException.java
+++ b/src/main/java/ubc/pavlab/rdp/exception/InvalidTokenSignatureException.java
@@ -1,0 +1,11 @@
+package ubc.pavlab.rdp.exception;
+
+/**
+ * Exception raised when the MAC signature of a token is invalid.
+ */
+public class InvalidTokenSignatureException extends TokenException {
+
+    public InvalidTokenSignatureException( String message ) {
+        super( message );
+    }
+}

--- a/src/main/java/ubc/pavlab/rdp/services/UserService.java
+++ b/src/main/java/ubc/pavlab/rdp/services/UserService.java
@@ -3,6 +3,7 @@ package ubc.pavlab.rdp.services;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.BadCredentialsException;
+import ubc.pavlab.rdp.exception.InvalidTokenSignatureException;
 import ubc.pavlab.rdp.exception.TokenException;
 import ubc.pavlab.rdp.model.*;
 import ubc.pavlab.rdp.model.enums.PrivacyLevelType;
@@ -158,4 +159,8 @@ public interface UserService {
     long computeTermFrequencyInTaxon( User user, GeneOntologyTerm term, Taxon taxon );
 
     void sendGeneAccessRequest( User requestingUser, UserGene userGene, String reason );
+
+    String createSecureRandomToken();
+
+    void verifySecureRandomToken(String token) throws InvalidTokenSignatureException;
 }

--- a/src/main/java/ubc/pavlab/rdp/settings/ApplicationSettings.java
+++ b/src/main/java/ubc/pavlab/rdp/settings/ApplicationSettings.java
@@ -12,9 +12,7 @@ import ubc.pavlab.rdp.model.enums.ResearcherPosition;
 import ubc.pavlab.rdp.model.enums.TierType;
 import ubc.pavlab.rdp.services.GeneInfoService;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 import java.net.URI;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -221,6 +219,18 @@ public class ApplicationSettings {
     private PrivacySettings privacy;
     private CacheSettings cache;
     private OrganSettings organs;
+
+    /**
+     * Algorithm used for token signatures.
+     */
+    @NotEmpty
+    private String signatureAlgorithm;
+
+    /**
+     * Secret key used for token signatures.
+     */
+    @NotEmpty
+    private String signatureKey;
 
     private Resource faqFile;
     private boolean sendEmailOnRegistration;

--- a/src/main/java/ubc/pavlab/rdp/util/MacFactory.java
+++ b/src/main/java/ubc/pavlab/rdp/util/MacFactory.java
@@ -1,0 +1,50 @@
+package ubc.pavlab.rdp.util;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+import javax.crypto.Mac;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.AlgorithmParameterSpec;
+
+/**
+ * Factory for {@link Mac} instances.
+ *
+ * @author poirigui
+ */
+@Getter
+@Setter
+public class MacFactory implements InitializingBean {
+
+    private String algorithm;
+
+    private Key key;
+
+    private AlgorithmParameterSpec algorithmParameterSpec;
+
+    public Mac createMac() {
+        try {
+            Mac instance = Mac.getInstance( algorithm );
+            if ( algorithmParameterSpec != null ) {
+                instance.init( key, algorithmParameterSpec );
+            } else {
+                instance.init( key );
+            }
+            return instance;
+        } catch ( NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeyException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.notNull( algorithm, "The algorithm must be set." );
+        Assert.notNull( key, "The key must be set." );
+        Mac.getInstance( algorithm );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -107,6 +107,10 @@ server.compression.enabled=true
 # = Application Specific Defaults
 # ==============================================================
 
+# Algorithm and secret key for token signatures
+rdp.settings.signature-algorithm=HmacSHA256
+rdp.settings.signature-key=
+
 # Cached gene, orthologs, annotations, etc.
 rdp.settings.cache.enabled=true
 rdp.settings.cache.load-from-disk=false

--- a/src/test/java/ubc/pavlab/rdp/services/RemoteResourceServiceTest.java
+++ b/src/test/java/ubc/pavlab/rdp/services/RemoteResourceServiceTest.java
@@ -28,6 +28,7 @@ import ubc.pavlab.rdp.settings.ApplicationSettings;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.EnumSet;
 import java.util.UUID;
 
@@ -180,7 +181,7 @@ public class RemoteResourceServiceTest {
 
     @Test
     public void findGenesBySymbol_whenRequestTimeoutIsSet_thenSucceed() throws JsonProcessingException {
-        when( iSearchSettings.getRequestTimeout() ).thenReturn( 3 );
+        when( iSearchSettings.getRequestTimeout() ).thenReturn( Duration.ofSeconds( 3 ) );
         MockRestServiceServer mockServer = MockRestServiceServer.createServer( asyncRestTemplate );
         mockServer.expect( requestTo( "http://example.com/api/genes/search?symbol=ok&taxonId=9606&tier=TIER1" ) )
                 .andRespond( withStatus( HttpStatus.OK )


### PR DESCRIPTION
The format is a 24 byte random token followed by a signature that is then base64 encoded and passed on to the user.


 - [ ] add more documentation for admins
 - [ ] fix feedback when the key is missing on boot
 - [ ] fix tests
 - [ ] don't store the token signature in the databas
- [ ] move token creation and verification routines outside UserService to ease reuse