### PR TITLE
Update Spring Boot to 2.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.10</version>
+        <version>2.7.2</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Release notes: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes

The test fail because of Flyway incompatibilities with the H2 update.